### PR TITLE
n iOS 8 and later, the maximum size allowed for a notification payload

### DIFF
--- a/src/main/java/javapns/notification/PushNotificationPayload.java
+++ b/src/main/java/javapns/notification/PushNotificationPayload.java
@@ -15,6 +15,9 @@ import org.json.JSONObject;
  */
 public class PushNotificationPayload extends Payload {
   /* Maximum total length (serialized) of a payload */
+  private static final int MAXIMUM_PAYLOAD_LENGTH = 2048;
+  
+  @Deprecated
   private static final int MAXIMUM_PAYLOAD_LENGTH = 256;
 
   /**


### PR DESCRIPTION
is 2 kilobytes. Modified the MAXIMUM_PAYLOAD_LENGTH.