### PR TITLE
Multiple code improvements - squid:S1118, squid:S00108

### DIFF
--- a/src/main/java/javapns/Push.java
+++ b/src/main/java/javapns/Push.java
@@ -13,6 +13,8 @@ import javapns.notification.*;
 import javapns.notification.transmission.NotificationThread;
 import javapns.notification.transmission.NotificationThreads;
 import javapns.notification.transmission.PushQueue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Vector;
@@ -32,6 +34,9 @@ import java.util.Vector;
  * @see NotificationThreads
  */
 public class Push {
+
+  private static final Logger logger = LoggerFactory.getLogger(Push.class);
+
   private Push() {
     // empty
   }
@@ -184,6 +189,7 @@ public class Push {
       try {
         pushManager.stopConnection();
       } catch (final Exception e) {
+        logger.error(e.getMessage(), e);
       }
     }
     return notifications;
@@ -212,6 +218,7 @@ public class Push {
     try {
       threads.waitForAllThreads(true);
     } catch (final InterruptedException e) {
+      logger.error(e.getMessage(), e);
     }
     return threads.getPushedNotifications();
   }
@@ -272,6 +279,7 @@ public class Push {
     try {
       threads.waitForAllThreads(true);
     } catch (final InterruptedException e) {
+      logger.error(e.getMessage(), e);
     }
     return threads.getPushedNotifications();
   }
@@ -312,6 +320,7 @@ public class Push {
       try {
         pushManager.stopConnection();
       } catch (final Exception e) {
+        logger.error(e.getMessage(), e);
       }
     }
     return notifications;

--- a/src/main/java/javapns/communication/KeystoreManager.java
+++ b/src/main/java/javapns/communication/KeystoreManager.java
@@ -21,6 +21,8 @@ import java.util.Enumeration;
 public class KeystoreManager {
   private static final String REVIEW_MESSAGE = " Please review the procedure for generating a keystore for JavaPNS.";
 
+  private KeystoreManager() {}
+
   /**
    * Loads a keystore.
    *

--- a/src/main/java/javapns/devices/Devices.java
+++ b/src/main/java/javapns/devices/Devices.java
@@ -8,6 +8,9 @@ import java.util.List;
 import java.util.Vector;
 
 public class Devices {
+
+  private Devices() {}
+
   public static List<Device> asDevices(final Object rawList) {
     final List<Device> list = new Vector<>();
     if (rawList == null) {

--- a/src/main/java/javapns/notification/PushNotificationPayload.java
+++ b/src/main/java/javapns/notification/PushNotificationPayload.java
@@ -125,6 +125,7 @@ public class PushNotificationPayload extends Payload {
     try {
       payload.addSound(sound);
     } catch (final JSONException e) {
+      logger.error(e.getMessage(), e);
     }
     return payload;
   }
@@ -153,6 +154,7 @@ public class PushNotificationPayload extends Payload {
         payload.addSound(sound);
       }
     } catch (final JSONException e) {
+      logger.error(e.getMessage(), e);
     }
     return payload;
   }

--- a/src/main/java/javapns/notification/ResponsePacketReader.java
+++ b/src/main/java/javapns/notification/ResponsePacketReader.java
@@ -17,6 +17,8 @@ class ResponsePacketReader {
   /* The number of seconds to wait for a response */
   private static final int TIMEOUT = 5 * 1000;
 
+  private ResponsePacketReader() {}
+
   /**
    * Read response packets from the current APNS connection and process them.
    *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors.
squid:S00108 - Nested blocks of code should not be left empty.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S00108
Please let me know if you have any questions.
George Kankava
