### PR TITLE
Multiple code improvements - squid:S1192, squid:S1155, squid:S1197

### DIFF
--- a/src/main/java/javapns/communication/ConnectionToAppleServer.java
+++ b/src/main/java/javapns/communication/ConnectionToAppleServer.java
@@ -175,7 +175,7 @@ public abstract class ConnectionToAppleServer {
     final OutputStream out = tunnel.getOutputStream();
 
     final String msg = "CONNECT " + host + ":" + port + " HTTP/1.0\n" + "User-Agent: BoardPad Server" + "\r\n\r\n";
-    byte b[];
+    byte[] b;
     try { //We really do want ASCII7 -- the http protocol doesn't change with locale.
       b = msg.getBytes("ASCII7");
     } catch (final UnsupportedEncodingException ignored) { //If ASCII7 isn't there, something serious is wrong, but Paranoia Is Good (tm)

--- a/src/main/java/javapns/devices/Devices.java
+++ b/src/main/java/javapns/devices/Devices.java
@@ -16,7 +16,7 @@ public class Devices {
 
     if (rawList instanceof List) {
       final List devices = (List) rawList;
-      if (devices.size() == 0) {
+      if (devices.isEmpty()) {
         return list;
       }
 
@@ -60,7 +60,7 @@ public class Devices {
     }
     if (rawList instanceof List) {
       final List devices = (List) rawList;
-      if (devices.size() == 0) {
+      if (devices.isEmpty()) {
         return list;
       }
       //noinspection unchecked

--- a/src/main/java/javapns/notification/Payload.java
+++ b/src/main/java/javapns/notification/Payload.java
@@ -24,6 +24,9 @@ public abstract class Payload {
 
   /* Character encoding specified by Apple documentation */
   private static final String DEFAULT_CHARACTER_ENCODING = "UTF-8";
+  private static final String ADDING_CUSTOM_DICTIONARY = "Adding custom Dictionary [";
+  private static final String DELIMITER_START = "] = [";
+  private static final String DELIMITED_END = "]";
   /* The root Payload */
   private final JSONObject payload;
 
@@ -74,7 +77,7 @@ public abstract class Payload {
    * @throws JSONException
    */
   public void addCustomDictionary(final String name, final String value) throws JSONException {
-    logger.debug("Adding custom Dictionary [" + name + "] = [" + value + "]");
+    logger.debug(ADDING_CUSTOM_DICTIONARY + name + DELIMITER_START + value + DELIMITED_END);
     put(name, value, payload, false);
   }
 
@@ -86,7 +89,7 @@ public abstract class Payload {
    * @throws JSONException
    */
   public void addCustomDictionary(final String name, final int value) throws JSONException {
-    logger.debug("Adding custom Dictionary [" + name + "] = [" + value + "]");
+    logger.debug(ADDING_CUSTOM_DICTIONARY + name + DELIMITER_START + value + DELIMITED_END);
     put(name, value, payload, false);
   }
 
@@ -98,7 +101,7 @@ public abstract class Payload {
    * @throws JSONException
    */
   public void addCustomDictionary(final String name, final List values) throws JSONException {
-    logger.debug("Adding custom Dictionary [" + name + "] = (list)");
+    logger.debug(ADDING_CUSTOM_DICTIONARY + name + "] = (list)");
     put(name, values, payload, false);
   }
 
@@ -110,7 +113,7 @@ public abstract class Payload {
    * @throws JSONException
    */
   public void addCustomDictionary(final String name, final Object value) throws JSONException {
-    logger.debug("Adding custom Dictionary [" + name + "] = [" + value + "]");
+    logger.debug(ADDING_CUSTOM_DICTIONARY + name + DELIMITER_START + value + DELIMITED_END);
     put(name, value, payload, false);
   }
 

--- a/src/main/java/javapns/notification/PushNotificationPayload.java
+++ b/src/main/java/javapns/notification/PushNotificationPayload.java
@@ -15,6 +15,7 @@ import java.util.List;
 public class PushNotificationPayload extends Payload {
   /* Maximum total length (serialized) of a payload */
   private static final int MAXIMUM_PAYLOAD_LENGTH = 256;
+  public static final String ALERT = "alert";
 
   /* The application Dictionary */
   private JSONObject apsDictionary;
@@ -223,9 +224,9 @@ public class PushNotificationPayload extends Payload {
    * @throws JSONException
    */
   public void addAlert(final String alertMessage) throws JSONException {
-    final String previousAlert = getCompatibleProperty("alert", String.class, "A custom alert (\"%s\") was already added to this payload");
+    final String previousAlert = getCompatibleProperty(ALERT, String.class, "A custom alert (\"%s\") was already added to this payload");
     logger.debug("Adding alert [" + alertMessage + "]" + (previousAlert != null ? " replacing previous alert [" + previousAlert + "]" : ""));
-    put("alert", alertMessage, this.apsDictionary, false);
+    put(ALERT, alertMessage, this.apsDictionary, false);
   }
 
   /**
@@ -235,10 +236,10 @@ public class PushNotificationPayload extends Payload {
    * @throws JSONException if a simple alert has already been added to this payload
    */
   private JSONObject getOrAddCustomAlert() throws JSONException {
-    JSONObject alert = getCompatibleProperty("alert", JSONObject.class, "A simple alert (\"%s\") was already added to this payload");
+    JSONObject alert = getCompatibleProperty(ALERT, JSONObject.class, "A simple alert (\"%s\") was already added to this payload");
     if (alert == null) {
       alert = new JSONObject();
-      put("alert", alert, this.apsDictionary, false);
+      put(ALERT, alert, this.apsDictionary, false);
     }
     return alert;
   }

--- a/src/main/java/javapns/notification/transmission/NotificationThread.java
+++ b/src/main/java/javapns/notification/transmission/NotificationThread.java
@@ -32,6 +32,9 @@ import java.util.Vector;
  */
 public class NotificationThread implements Runnable, PushQueue {
   private static final int DEFAULT_MAXNOTIFICATIONSPERCONNECTION = 200;
+  private static final String JAVA_PNS = "JavaPNS";
+  private static final String STANDALONE = " standalone";
+  private static final String GROUPED = " grouped";
 
   private final Thread thread;
   private final AppleNotificationServer server;
@@ -69,7 +72,7 @@ public class NotificationThread implements Runnable, PushQueue {
    * @param devices             a list or an array of tokens or devices: {@link java.lang.String String[]}, {@link java.util.List}<{@link java.lang.String}>, {@link javapns.devices.Device Device[]}, {@link java.util.List}<{@link javapns.devices.Device}>, {@link java.lang.String} or {@link javapns.devices.Device}
    */
   public NotificationThread(final NotificationThreads threads, final PushNotificationManager notificationManager, final AppleNotificationServer server, final Payload payload, final Object devices) {
-    this.thread = new Thread(threads, this, "JavaPNS" + (threads != null ? " grouped" : " standalone") + " notification thread in LIST mode");
+    this.thread = new Thread(threads, this, JAVA_PNS + (threads != null ? GROUPED : STANDALONE) + " notification thread in LIST mode");
     this.notificationManager = notificationManager == null ? new PushNotificationManager() : notificationManager;
     this.server = server;
     this.payload = payload;
@@ -87,7 +90,7 @@ public class NotificationThread implements Runnable, PushQueue {
    * @param messages            a list or an array of PayloadPerDevice: {@link java.util.List}<{@link javapns.notification.PayloadPerDevice}>, {@link javapns.notification.PayloadPerDevice PayloadPerDevice[]} or {@link javapns.notification.PayloadPerDevice}
    */
   public NotificationThread(final NotificationThreads threads, final PushNotificationManager notificationManager, final AppleNotificationServer server, final Object messages) {
-    this.thread = new Thread(threads, this, "JavaPNS" + (threads != null ? " grouped" : " standalone") + " notification thread in LIST mode");
+    this.thread = new Thread(threads, this, JAVA_PNS + (threads != null ? GROUPED : STANDALONE) + " notification thread in LIST mode");
     this.notificationManager = notificationManager == null ? new PushNotificationManager() : notificationManager;
     this.server = server;
     this.messages = Devices.asPayloadsPerDevices(messages);
@@ -125,7 +128,7 @@ public class NotificationThread implements Runnable, PushQueue {
    * @param server              the server to communicate with
    */
   public NotificationThread(final NotificationThreads threads, final PushNotificationManager notificationManager, final AppleNotificationServer server) {
-    this.thread = new Thread(threads, this, "JavaPNS" + (threads != null ? " grouped" : " standalone") + " notification thread in QUEUE mode");
+    this.thread = new Thread(threads, this, JAVA_PNS + (threads != null ? GROUPED : STANDALONE) + " notification thread in QUEUE mode");
     this.notificationManager = notificationManager == null ? new PushNotificationManager() : notificationManager;
     this.server = server;
     this.mode = MODE.QUEUE;

--- a/src/main/java/javapns/notification/transmission/NotificationThreads.java
+++ b/src/main/java/javapns/notification/transmission/NotificationThreads.java
@@ -23,6 +23,8 @@ import java.util.stream.Collectors;
  */
 public class NotificationThreads extends ThreadGroup implements PushQueue {
   private static final long DEFAULT_DELAY_BETWEEN_THREADS = 500; // the number of milliseconds to wait between each thread startup
+  private static final String JAVAPNS_NOTIFICATION_THREADS = "javapns notification threads (";
+  private static final String THREADS = " threads)";
 
   private final Object finishPoint = new Object();
 
@@ -43,7 +45,7 @@ public class NotificationThreads extends ThreadGroup implements PushQueue {
    * @param numberOfThreads the number of threads to create to share the work
    */
   public NotificationThreads(final AppleNotificationServer server, final Payload payload, final List<Device> devices, final int numberOfThreads) {
-    super("javapns notification threads (" + numberOfThreads + " threads)");
+    super(JAVAPNS_NOTIFICATION_THREADS + numberOfThreads + THREADS);
     threads.addAll(makeGroups(devices, numberOfThreads).stream().map(deviceGroup -> new NotificationThread(this, new PushNotificationManager(), server, payload, deviceGroup)).collect(Collectors.toList()));
   }
 
@@ -55,7 +57,7 @@ public class NotificationThreads extends ThreadGroup implements PushQueue {
    * @param numberOfThreads the number of threads to create to share the work
    */
   public NotificationThreads(final AppleNotificationServer server, final List<PayloadPerDevice> messages, final int numberOfThreads) {
-    super("javapns notification threads (" + numberOfThreads + " threads)");
+    super(JAVAPNS_NOTIFICATION_THREADS + numberOfThreads + THREADS);
     threads.addAll(makeGroups(messages, numberOfThreads).stream().map(deviceGroup -> new NotificationThread(this, new PushNotificationManager(), server, deviceGroup)).collect(Collectors.toList()));
   }
 
@@ -85,7 +87,7 @@ public class NotificationThreads extends ThreadGroup implements PushQueue {
    */
   @SuppressWarnings("unchecked")
   private NotificationThreads(final AppleNotificationServer server, final Payload payload, final List<Device> devices, final List<NotificationThread> threads) {
-    super("javapns notification threads (" + threads.size() + " threads)");
+    super(JAVAPNS_NOTIFICATION_THREADS + threads.size() + THREADS);
     this.threads = threads;
     final List<List<?>> groups = makeGroups(devices, threads.size());
     for (int i = 0; i < groups.size(); i++) {
@@ -117,7 +119,7 @@ public class NotificationThreads extends ThreadGroup implements PushQueue {
    * @param threads a list of pre-built threads
    */
   private NotificationThreads(final AppleNotificationServer server, final Payload payload, final List<NotificationThread> threads) {
-    super("javapns notification threads (" + threads.size() + " threads)");
+    super(JAVAPNS_NOTIFICATION_THREADS + threads.size() + THREADS);
     this.threads = threads;
   }
 
@@ -144,7 +146,7 @@ public class NotificationThreads extends ThreadGroup implements PushQueue {
    * @param numberOfThreads the number of threads to create in the pool
    */
   public NotificationThreads(final AppleNotificationServer server, final int numberOfThreads) {
-    super("javapns notification thread pool (" + numberOfThreads + " threads)");
+    super("javapns notification thread pool (" + numberOfThreads + THREADS);
     for (int i = 0; i < numberOfThreads; i++) {
       threads.add(new NotificationThread(this, new PushNotificationManager(), server));
     }
@@ -376,7 +378,7 @@ public class NotificationThreads extends ThreadGroup implements PushQueue {
     waitForAllThreads();
     if (throwCriticalExceptions) {
       final List<Exception> exceptions = getCriticalExceptions();
-      if (exceptions.size() > 0) {
+      if (!exceptions.isEmpty()) {
         throw exceptions.get(0);
       }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1192 - String literals should not be duplicated.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S1197
Please let me know if you have any questions.
George Kankava
