### PR TITLE
Multiple code improvements - squid:S1148, squid:S1854, squid:S1481

### DIFF
--- a/src/main/java/javapns/notification/NewsstandNotificationPayload.java
+++ b/src/main/java/javapns/notification/NewsstandNotificationPayload.java
@@ -2,6 +2,8 @@ package javapns.notification;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A Newsstand-specific payload compatible with the Apple Push Notification Service.
@@ -9,6 +11,9 @@ import org.json.JSONObject;
  * @author Sylvain Pedneault
  */
 public class NewsstandNotificationPayload extends Payload {
+
+  static final Logger logger = LoggerFactory.getLogger(NewsstandNotificationPayload.class);
+
   /* The application Dictionnary */
   private final JSONObject apsDictionary;
 
@@ -22,7 +27,7 @@ public class NewsstandNotificationPayload extends Payload {
       final JSONObject payload = getPayload();
       payload.put("aps", this.apsDictionary);
     } catch (final JSONException e) {
-      e.printStackTrace();
+      logger.error(e.getMessage(), e);
     }
   }
 

--- a/src/main/java/javapns/notification/PushNotificationManager.java
+++ b/src/main/java/javapns/notification/PushNotificationManager.java
@@ -261,7 +261,6 @@ public class PushNotificationManager {
       logger.debug("Reading responses");
       int responsesReceived = ResponsePacketReader.processResponses(this);
       while (responsesReceived > 0) {
-        final PushedNotification skippedNotification = null;
         final List<PushedNotification> notificationsToResend = new ArrayList<>();
         boolean foundFirstFail = false;
         for (final PushedNotification notification : pushedNotifications.values()) {
@@ -442,7 +441,6 @@ public class PushNotificationManager {
 
       boolean success = false;
 
-      final BufferedReader in = new BufferedReader(new InputStreamReader(this.socket.getInputStream()));
       final int socketTimeout = getSslSocketTimeout();
       if (socketTimeout > 0) {
         this.socket.setSoTimeout(socketTimeout);

--- a/src/main/java/javapns/notification/PushNotificationPayload.java
+++ b/src/main/java/javapns/notification/PushNotificationPayload.java
@@ -3,6 +3,8 @@ package javapns.notification;
 import javapns.notification.exceptions.PayloadAlertAlreadyExistsException;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -13,6 +15,9 @@ import java.util.List;
  * @author Sylvain Pedneault
  */
 public class PushNotificationPayload extends Payload {
+
+  static final Logger logger = LoggerFactory.getLogger(PushNotificationPayload.class);
+
   /* Maximum total length (serialized) of a payload */
   private static final int MAXIMUM_PAYLOAD_LENGTH = 256;
 
@@ -31,7 +36,7 @@ public class PushNotificationPayload extends Payload {
         payload.put("aps", this.apsDictionary);
       }
     } catch (final JSONException e) {
-      e.printStackTrace();
+      logger.error(e.getMessage(), e);
     }
   }
 
@@ -53,7 +58,7 @@ public class PushNotificationPayload extends Payload {
       }
 
     } catch (final JSONException e) {
-      e.printStackTrace();
+      logger.error(e.getMessage(), e);
     }
   }
 

--- a/src/main/java/javapns/notification/ResponsePacketReader.java
+++ b/src/main/java/javapns/notification/ResponsePacketReader.java
@@ -74,7 +74,6 @@ class ResponsePacketReader {
   }
 
   private static void handleResponses(final List<ResponsePacket> responses, final PushNotificationManager notificationManager) {
-    final Map<Integer, PushedNotification> envelopes = notificationManager.getPushedNotifications();
     for (final ResponsePacket response : responses) {
       response.linkToPushedNotification(notificationManager);
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1148 - Throwable.printStackTrace(...) should not be called.
squid:S1854 - Dead stores should be removed.
squid:S1481 - Unused local variables should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1148
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1481
Please let me know if you have any questions.
George Kankava
