### PR TITLE
squid:CommentedOutCodeLine - Sections of code should not be 'commented out'

### DIFF
--- a/src/main/java/javapns/communication/ServerTrustingTrustManager.java
+++ b/src/main/java/javapns/communication/ServerTrustingTrustManager.java
@@ -20,6 +20,6 @@ class ServerTrustingTrustManager implements X509TrustManager {
   }
 
   public X509Certificate[] getAcceptedIssuers() {
-    return null;//new X509Certificate[0];
+    return null;
   }
 }

--- a/src/main/java/javapns/feedback/FeedbackServiceManager.java
+++ b/src/main/java/javapns/feedback/FeedbackServiceManager.java
@@ -153,23 +153,6 @@ public class FeedbackServiceManager {
     return listDev;
   }
 
-  //  /**
-  //   * Set the proxy if needed
-  //   * @param host the proxyHost
-  //   * @param port the proxyPort
-  //   * @deprecated Configuring a proxy with this method affects overall JVM proxy settings.
-  //   * Use AppleFeedbackServer.setProxy(..) to set a proxy for JavaPNS only.
-  //   */
-  //  public void setProxy(String host, String port) {
-  //    this.proxySet = true;
-  //
-  //    System.setProperty("http.proxyHost", host);
-  //    System.setProperty("http.proxyPort", port);
-  //
-  //    System.setProperty("https.proxyHost", host);
-  //    System.setProperty("https.proxyPort", port);
-  //  }
-
   /**
    * @return a device factory
    * @deprecated The DeviceFactory-based architecture is deprecated.

--- a/src/main/java/javapns/notification/PushNotificationManager.java
+++ b/src/main/java/javapns/notification/PushNotificationManager.java
@@ -370,23 +370,6 @@ public class PushNotificationManager {
     return sendNotification(device, payload, false, identifier);
   }
 
-  //  /**
-  //   * Set the proxy if needed
-  //   * @param host the proxyHost
-  //   * @param port the proxyPort
-  //   * @deprecated Configuring a proxy with this method affects overall JVM proxy settings.
-  //   * Use AppleNotificationServer.setProxy(..) to set a proxy for JavaPNS only.
-  //   */
-  //  public void setProxy(String host, String port) {
-  //    proxySet = true;
-  //
-  //    System.setProperty("http.proxyHost", host);
-  //    System.setProperty("http.proxyPort", port);
-  //
-  //    System.setProperty("https.proxyHost", host);
-  //    System.setProperty("https.proxyPort", port);
-  //  }
-
   /**
    * Send a notification (Payload) to the given device
    *
@@ -433,9 +416,7 @@ public class PushNotificationManager {
       final String token = device.getToken();
       // even though the BasicDevice constructor validates the token, we revalidate it in case we were passed another implementation of Device
       BasicDevice.validateTokenFormat(token);
-      //    PushedNotification pushedNotification = new PushedNotification(device, payload);
       final byte[] bytes = getMessage(token, payload, identifier, notification);
-      //    pushedNotifications.put(pushedNotification.getIdentifier(), pushedNotification);
 
       /* Special simulation mode to skip actual streaming of message */
       final boolean simulationMode = payload.getExpiry() == 919191;
@@ -582,7 +563,6 @@ public class PushNotificationManager {
     logger.debug("Building Raw message from deviceToken and payload");
 
     /* To test with a corrupted or invalid token, uncomment following line*/
-    //deviceToken = deviceToken.substring(0,10);
 
     // First convert the deviceToken (in hexa form) to a binary format
     final byte[] deviceTokenAsBytes = new byte[deviceToken.length() / 2];

--- a/src/main/java/javapns/notification/ResponsePacketReader.java
+++ b/src/main/java/javapns/notification/ResponsePacketReader.java
@@ -61,7 +61,6 @@ class ResponsePacketReader {
 
     } catch (final Exception e) {
       /* Ignore exception, as we are expecting timeout exceptions because Apple might not reply anything */
-      //System.out.println(e);
     }
     /* Reset socket timeout, just in case */
     try {
@@ -69,7 +68,6 @@ class ResponsePacketReader {
     } catch (final Exception e) {
       // empty
     }
-    //System.out.println("Received "+responses.size()+" response packets");
     return responses;
   }
 

--- a/src/main/java/javapns/notification/transmission/NotificationThreads.java
+++ b/src/main/java/javapns/notification/transmission/NotificationThreads.java
@@ -164,7 +164,6 @@ public class NotificationThreads extends ThreadGroup implements PushQueue {
     if (total % threads > 0) {
       devicesPerThread++;
     }
-    //System.out.println("Making "+threads+" groups of "+devicesPerThread+" devices out of "+total+" devices in total");
     for (int i = 0; i < threads; i++) {
       final int firstObject = i * devicesPerThread;
       if (firstObject >= total) {
@@ -175,7 +174,6 @@ public class NotificationThreads extends ThreadGroup implements PushQueue {
         lastObject = total - 1;
       }
       lastObject++;
-      //System.out.println("Grouping together "+(lastDevice-firstDevice)+" devices (#"+firstDevice+" to "+lastDevice+")");
       final List threadObjects = objects.subList(firstObject, lastObject);
       groups.add(threadObjects);
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:CommentedOutCodeLine - Sections of code should not be commented out.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
Please let me know if you have any questions.
George Kankava
