### PR TITLE
Multiple code improvements - squid:S1149, squid:UselessParenthesesCheck

### DIFF
--- a/src/main/java/javapns/notification/transmission/NotificationThread.java
+++ b/src/main/java/javapns/notification/transmission/NotificationThread.java
@@ -7,6 +7,7 @@ import javapns.devices.Devices;
 import javapns.devices.exceptions.InvalidDeviceTokenFormatException;
 import javapns.notification.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
@@ -54,7 +55,7 @@ public class NotificationThread implements Runnable, PushQueue {
   private List<Device> devices;
   /* Individual payload per device */
 
-  private List<PayloadPerDevice> messages = new Vector<>();
+  private List<PayloadPerDevice> messages = new ArrayList<>();
 
   private Exception exception;
 
@@ -504,7 +505,7 @@ public class NotificationThread implements Runnable, PushQueue {
    * @return a list containing a critical exception, if any occurred
    */
   public List<Exception> getCriticalExceptions() {
-    final List<Exception> exceptions = new Vector<>(exception == null ? 0 : 1);
+    final List<Exception> exceptions = new ArrayList<>(exception == null ? 0 : 1);
     if (exception != null) {
       exceptions.add(exception);
     }

--- a/src/main/java/javapns/notification/transmission/NotificationThreads.java
+++ b/src/main/java/javapns/notification/transmission/NotificationThreads.java
@@ -5,6 +5,7 @@ import javapns.devices.Devices;
 import javapns.devices.exceptions.InvalidDeviceTokenFormatException;
 import javapns.notification.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 import java.util.stream.Collectors;
@@ -26,7 +27,7 @@ public class NotificationThreads extends ThreadGroup implements PushQueue {
 
   private final Object finishPoint = new Object();
 
-  private List<NotificationThread> threads = new Vector<>();
+  private List<NotificationThread> threads = new ArrayList<>();
   private NotificationProgressListener listener;
 
   private boolean started = false;
@@ -158,9 +159,9 @@ public class NotificationThreads extends ThreadGroup implements PushQueue {
    * @return
    */
   private static List<List<?>> makeGroups(final List<?> objects, final int threads) {
-    final List<List<?>> groups = new Vector<>(threads);
+    final List<List<?>> groups = new ArrayList<>(threads);
     final int total = objects.size();
-    int devicesPerThread = (total / threads);
+    int devicesPerThread = total / threads;
     if (total % threads > 0) {
       devicesPerThread++;
     }
@@ -449,7 +450,7 @@ public class NotificationThreads extends ThreadGroup implements PushQueue {
    * @return a list of critical exceptions
    */
   public List<Exception> getCriticalExceptions() {
-    final List<Exception> exceptions = new Vector<>();
+    final List<Exception> exceptions = new ArrayList<>();
     for (final NotificationThread thread : threads) {
       final Exception exception = thread.getCriticalException();
       if (exception != null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1149
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava
