### PR TITLE
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/src/main/java/javapns/Push.java
+++ b/src/main/java/javapns/Push.java
@@ -14,8 +14,8 @@ import javapns.notification.transmission.NotificationThread;
 import javapns.notification.transmission.NotificationThreads;
 import javapns.notification.transmission.PushQueue;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
 
 /**
  * <p>Main class for easily interacting with the Apple Push Notification System</p>
@@ -347,7 +347,7 @@ public class Push {
    * @throws CommunicationException thrown if an unrecoverable error occurs while trying to communicate with Apple servers
    */
   public static List<Device> feedback(final Object keystore, final String password, final boolean production) throws CommunicationException, KeystoreException {
-    final List<Device> devices = new Vector<>();
+    final List<Device> devices = new ArrayList<>();
     final FeedbackServiceManager feedbackManager = new FeedbackServiceManager();
     final AppleFeedbackServer server = new AppleFeedbackServerBasicImpl(keystore, password, production);
     devices.addAll(feedbackManager.getDevices(server));

--- a/src/main/java/javapns/devices/Devices.java
+++ b/src/main/java/javapns/devices/Devices.java
@@ -3,13 +3,13 @@ package javapns.devices;
 import javapns.devices.implementations.basic.BasicDevice;
 import javapns.notification.PayloadPerDevice;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Vector;
 
 public class Devices {
   public static List<Device> asDevices(final Object rawList) {
-    final List<Device> list = new Vector<>();
+    final List<Device> list = new ArrayList<>();
     if (rawList == null) {
       return list;
     }
@@ -54,7 +54,7 @@ public class Devices {
   }
 
   public static List<PayloadPerDevice> asPayloadsPerDevices(final Object rawList) {
-    final List<PayloadPerDevice> list = new Vector<>();
+    final List<PayloadPerDevice> list = new ArrayList<>();
     if (rawList == null) {
       return list;
     }

--- a/src/main/java/javapns/notification/PushedNotification.java
+++ b/src/main/java/javapns/notification/PushedNotification.java
@@ -3,8 +3,8 @@ package javapns.notification;
 import javapns.devices.Device;
 import javapns.notification.exceptions.ErrorResponsePacketReceivedException;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
 
 /**
  * <p>An object representing the result of a push notification to a specific payload to a single device.</p>
@@ -53,7 +53,7 @@ public class PushedNotification {
    * @return a filtered list containing only notifications that were succcessful
    */
   public static List<PushedNotification> findSuccessfulNotifications(final List<PushedNotification> notifications) {
-    final List<PushedNotification> filteredList = new Vector<>();
+    final List<PushedNotification> filteredList = new ArrayList<>();
     for (final PushedNotification notification : notifications) {
       if (notification.isSuccessful()) {
         filteredList.add(notification);
@@ -69,7 +69,7 @@ public class PushedNotification {
    * @return a filtered list containing only notifications that were <b>not</b> successful
    */
   public static List<PushedNotification> findFailedNotifications(final List<PushedNotification> notifications) {
-    final List<PushedNotification> filteredList = new Vector<>();
+    final List<PushedNotification> filteredList = new ArrayList<>();
     for (final PushedNotification notification : notifications) {
       if (!notification.isSuccessful()) {
         filteredList.add(notification);

--- a/src/main/java/javapns/notification/PushedNotifications.java
+++ b/src/main/java/javapns/notification/PushedNotifications.java
@@ -1,5 +1,6 @@
 package javapns.notification;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Vector;
@@ -13,7 +14,7 @@ import java.util.Vector;
  *
  * @author Sylvain Pedneault
  */
-public class PushedNotifications extends Vector<PushedNotification> implements List<PushedNotification> {
+public class PushedNotifications extends ArrayList<PushedNotification> implements List<PushedNotification> {
   private static final long serialVersionUID = 1418782231076330494L;
   private int maxRetained = 1000;
 
@@ -75,12 +76,6 @@ public class PushedNotifications extends Vector<PushedNotification> implements L
   public synchronized boolean add(final PushedNotification notification) {
     prepareAdd(1);
     return super.add(notification);
-  }
-
-  @Override
-  public synchronized void addElement(final PushedNotification notification) {
-    prepareAdd(1);
-    super.addElement(notification);
   }
 
   @Override

--- a/src/main/java/javapns/notification/ResponsePacketReader.java
+++ b/src/main/java/javapns/notification/ResponsePacketReader.java
@@ -3,6 +3,7 @@ package javapns.notification;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.Socket;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
@@ -39,7 +40,7 @@ class ResponsePacketReader {
    * @return
    */
   private static List<ResponsePacket> readResponses(final Socket socket) {
-    final List<ResponsePacket> responses = new Vector<>();
+    final List<ResponsePacket> responses = new ArrayList<>();
     int previousTimeout = 0;
     try {
       /* Set socket timeout to avoid getting stuck on read() */


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
George Kankava
