### PR TITLE
Multiple code improvements - squid:S2160, squid:S1226

### DIFF
--- a/src/main/java/javapns/communication/ConnectionToAppleServer.java
+++ b/src/main/java/javapns/communication/ConnectionToAppleServer.java
@@ -89,8 +89,8 @@ public abstract class ConnectionToAppleServer {
         final char[] password = KeystoreManager.getKeystorePasswordForSSL(server);
         kmf.init(keystore, password);
       } catch (Exception e) {
-        e = KeystoreManager.wrapKeystoreException(e);
-        throw e;
+        final KeystoreException wrappedKeystoreException = KeystoreManager.wrapKeystoreException(e);
+        throw wrappedKeystoreException;
       }
 
       // Get the SSLContext to help create SSLSocketFactory

--- a/src/main/java/javapns/communication/KeystoreManager.java
+++ b/src/main/java/javapns/communication/KeystoreManager.java
@@ -82,7 +82,7 @@ public class KeystoreManager {
    */
   static Object ensureReusableKeystore(final AppleServer server, Object keystore) throws KeystoreException {
     if (keystore instanceof InputStream) {
-      keystore = loadKeystore(server, keystore, false);
+      return loadKeystore(server, keystore, false);
     }
     return keystore;
   }
@@ -233,19 +233,11 @@ public class KeystoreManager {
       return;
     }
     if (keystore instanceof String) {
-      keystore = new File((String) keystore);
+      validateFileKeystore(new File((String) keystore));
+      return;
     }
     if (keystore instanceof File) {
-      final File file = (File) keystore;
-      if (!file.exists()) {
-        throw new InvalidKeystoreReferenceException("Invalid keystore reference.  File does not exist: " + file.getAbsolutePath());
-      }
-      if (!file.isFile()) {
-        throw new InvalidKeystoreReferenceException("Invalid keystore reference.  Path does not refer to a valid file: " + file.getAbsolutePath());
-      }
-      if (file.length() <= 0) {
-        throw new InvalidKeystoreReferenceException("Invalid keystore reference.  File is empty: " + file.getAbsolutePath());
-      }
+      validateFileKeystore((File) keystore);
       return;
     }
     if (keystore instanceof byte[]) {
@@ -256,6 +248,20 @@ public class KeystoreManager {
       return;
     }
     throw new InvalidKeystoreReferenceException(keystore);
+  }
+
+  private static void validateFileKeystore(File keystore) throws InvalidKeystoreReferenceException {
+    final File file = keystore;
+    if (!file.exists()) {
+      throw new InvalidKeystoreReferenceException("Invalid keystore reference.  File does not exist: " + file.getAbsolutePath());
+    }
+    if (!file.isFile()) {
+      throw new InvalidKeystoreReferenceException("Invalid keystore reference.  Path does not refer to a valid file: " + file.getAbsolutePath());
+    }
+    if (file.length() <= 0) {
+      throw new InvalidKeystoreReferenceException("Invalid keystore reference.  File is empty: " + file.getAbsolutePath());
+    }
+    return;
   }
 
 }

--- a/src/main/java/javapns/devices/implementations/basic/BasicDeviceFactory.java
+++ b/src/main/java/javapns/devices/implementations/basic/BasicDeviceFactory.java
@@ -53,8 +53,7 @@ public class BasicDeviceFactory implements DeviceFactory {
       throw new NullDeviceTokenException();
     } else {
       if (!this.devices.containsKey(id)) {
-        token = token.trim().replace(" ", "");
-        final BasicDevice device = new BasicDevice(id, token, new Timestamp(Calendar.getInstance().getTime().getTime()));
+        final BasicDevice device = new BasicDevice(id, token.trim().replace(" ", ""), new Timestamp(Calendar.getInstance().getTime().getTime()));
         this.devices.put(id, device);
         return device;
       } else {

--- a/src/main/java/javapns/notification/PushNotificationManager.java
+++ b/src/main/java/javapns/notification/PushNotificationManager.java
@@ -586,18 +586,18 @@ public class PushNotificationManager {
 
     // First convert the deviceToken (in hexa form) to a binary format
     final byte[] deviceTokenAsBytes = new byte[deviceToken.length() / 2];
-    deviceToken = deviceToken.toUpperCase();
+    final String upperCasedDeviceToken = deviceToken.toUpperCase();
     int j = 0;
     try {
-      for (int i = 0; i < deviceToken.length(); i += 2) {
-        final String t = deviceToken.substring(i, i + 2);
+      for (int i = 0; i < upperCasedDeviceToken.length(); i += 2) {
+        final String t = upperCasedDeviceToken.substring(i, i + 2);
         final int tmp = Integer.parseInt(t, 16);
         deviceTokenAsBytes[j++] = (byte) tmp;
       }
     } catch (final NumberFormatException e1) {
-      throw new InvalidDeviceTokenFormatException(deviceToken, e1.getMessage());
+      throw new InvalidDeviceTokenFormatException(upperCasedDeviceToken, e1.getMessage());
     }
-    preconfigurePayload(payload, identifier, deviceToken);
+    preconfigurePayload(payload, identifier, upperCasedDeviceToken);
     // Create the ByteArrayOutputStream which will contain the raw interface
     final byte[] payloadAsBytes = payload.getPayloadAsBytes();
     final int size = (Byte.SIZE / Byte.SIZE) + (Character.SIZE / Byte.SIZE) + deviceTokenAsBytes.length + (Character.SIZE / Byte.SIZE) + payloadAsBytes.length;

--- a/src/main/java/javapns/notification/PushNotificationPayload.java
+++ b/src/main/java/javapns/notification/PushNotificationPayload.java
@@ -4,6 +4,7 @@ import javapns.notification.exceptions.PayloadAlertAlreadyExistsException;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.IllegalFormatException;
 import java.util.List;
 
 /**
@@ -292,11 +293,10 @@ public class PushNotificationPayload extends Payload {
       return (T) propertyValue;
     }
     try {
-      exceptionMessage = String.format(exceptionMessage, propertyValue);
-    } catch (final Exception e) {
-      // empty
+      throw new PayloadAlertAlreadyExistsException(String.format(exceptionMessage, propertyValue));
+    } catch (final IllegalFormatException e) {
+      throw new PayloadAlertAlreadyExistsException(exceptionMessage);
     }
-    throw new PayloadAlertAlreadyExistsException(exceptionMessage);
 
   }
 

--- a/src/main/java/javapns/notification/PushedNotifications.java
+++ b/src/main/java/javapns/notification/PushedNotifications.java
@@ -1,5 +1,6 @@
 package javapns.notification;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Vector;
@@ -13,7 +14,7 @@ import java.util.Vector;
  *
  * @author Sylvain Pedneault
  */
-public class PushedNotifications extends Vector<PushedNotification> implements List<PushedNotification> {
+public class PushedNotifications extends ArrayList<PushedNotification> implements List<PushedNotification> {
   private static final long serialVersionUID = 1418782231076330494L;
   private int maxRetained = 1000;
 
@@ -78,12 +79,6 @@ public class PushedNotifications extends Vector<PushedNotification> implements L
   }
 
   @Override
-  public synchronized void addElement(final PushedNotification notification) {
-    prepareAdd(1);
-    super.addElement(notification);
-  }
-
-  @Override
   public synchronized boolean addAll(final Collection<? extends PushedNotification> notifications) {
     prepareAdd(notifications.size());
     return super.addAll(notifications);
@@ -115,5 +110,24 @@ public class PushedNotifications extends Vector<PushedNotification> implements L
    */
   public void setMaxRetained(final int maxRetained) {
     this.maxRetained = maxRetained;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+
+    PushedNotifications that = (PushedNotifications) o;
+
+    return maxRetained == that.maxRetained;
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + maxRetained;
+    return result;
   }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2160 - Subclasses that add fields should override "equals".
squid:S1226 - Method parameters, caught exceptions and foreach variables should not be reassigned.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2160
https://dev.eclipse.org/sonar/rules/show/squid:S1226
Please let me know if you have any questions.
George Kankava
