### PR TITLE
Multiple code improvements - squid:S2235, squid:S1488, squid:HiddenFieldCheck, squid:UselessParenthesesCheck, squid:S3008

### DIFF
--- a/src/main/java/javapns/Push.java
+++ b/src/main/java/javapns/Push.java
@@ -231,8 +231,7 @@ public class Push {
    */
   public static PushQueue queue(final Object keystore, final String password, final boolean production, final int numberOfThreads) throws KeystoreException {
     final AppleNotificationServer server = new AppleNotificationServerBasicImpl(keystore, password, production);
-    final PushQueue queue = numberOfThreads <= 1 ? new NotificationThread(server) : new NotificationThreads(server, numberOfThreads);
-    return queue;
+    return numberOfThreads <= 1 ? new NotificationThread(server) : new NotificationThreads(server, numberOfThreads);
   }
 
   /**

--- a/src/main/java/javapns/communication/ConnectionToAppleServer.java
+++ b/src/main/java/javapns/communication/ConnectionToAppleServer.java
@@ -132,14 +132,14 @@ public abstract class ConnectionToAppleServer {
    * @throws CommunicationException
    */
   public SSLSocket getSSLSocket() throws KeystoreException, CommunicationException {
-    final SSLSocketFactory socketFactory = getSSLSocketFactory();
+    final SSLSocketFactory sslSocketFactory = getSSLSocketFactory();
     logger.debug("Creating SSLSocket to " + getServerHost() + ":" + getServerPort());
 
     try {
       if (ProxyManager.isUsingProxy(server)) {
-        return tunnelThroughProxy(socketFactory);
+        return tunnelThroughProxy(sslSocketFactory);
       } else {
-        return (SSLSocket) socketFactory.createSocket(getServerHost(), getServerPort());
+        return (SSLSocket) sslSocketFactory.createSocket(getServerHost(), getServerPort());
       }
     } catch (final Exception e) {
       throw new CommunicationException("Communication exception: " + e, e);

--- a/src/main/java/javapns/feedback/FeedbackServiceManager.java
+++ b/src/main/java/javapns/feedback/FeedbackServiceManager.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.sql.Timestamp;
 import java.util.LinkedList;
+import java.util.List;
 
 /**
  * Class for interacting with a specific Feedback Service.
@@ -67,7 +68,7 @@ public class FeedbackServiceManager {
    * @throws KeystoreException
    * @throws CommunicationException
    */
-  public LinkedList<Device> getDevices(final AppleFeedbackServer server) throws KeystoreException, CommunicationException {
+  public List<Device> getDevices(final AppleFeedbackServer server) throws KeystoreException, CommunicationException {
     final ConnectionToFeedbackServer connectionHelper = new ConnectionToFeedbackServer(server);
     final SSLSocket socket = connectionHelper.getSSLSocket();
     return getDevices(socket);
@@ -111,10 +112,10 @@ public class FeedbackServiceManager {
         final int fourthByte;
         final long anUnsignedInt;
 
-        firstByte = (0x000000FF & ((int) listOfDevices[offset]));
-        secondByte = (0x000000FF & ((int) listOfDevices[offset + 1]));
-        thirdByte = (0x000000FF & ((int) listOfDevices[offset + 2]));
-        fourthByte = (0x000000FF & ((int) listOfDevices[offset + 3]));
+        firstByte = 0x000000FF & ((int) listOfDevices[offset]);
+        secondByte = 0x000000FF & ((int) listOfDevices[offset + 1]);
+        thirdByte = 0x000000FF & ((int) listOfDevices[offset + 2]);
+        fourthByte = 0x000000FF & ((int) listOfDevices[offset + 3]);
         anUnsignedInt = ((long) (firstByte << 24 | secondByte << 16 | thirdByte << 8 | fourthByte)) & 0xFFFFFFFFL;
         final Timestamp timestamp = new Timestamp(anUnsignedInt * 1000);
 
@@ -125,7 +126,7 @@ public class FeedbackServiceManager {
         String deviceToken = "";
         int octet;
         for (int j = 0; j < 32; j++) {
-          octet = (0x000000FF & ((int) listOfDevices[offset + 6 + j]));
+          octet = 0x000000FF & ((int) listOfDevices[offset + 6 + j]);
           deviceToken = deviceToken.concat(String.format("%02x", octet));
         }
 

--- a/src/main/java/javapns/notification/NewsstandNotificationPayload.java
+++ b/src/main/java/javapns/notification/NewsstandNotificationPayload.java
@@ -50,8 +50,7 @@ public class NewsstandNotificationPayload extends Payload {
    * @return a blank payload that can be customized
    */
   private static NewsstandNotificationPayload complex() {
-    final NewsstandNotificationPayload payload = new NewsstandNotificationPayload();
-    return payload;
+    return new NewsstandNotificationPayload();
   }
 
   private void addContentAvailable() throws JSONException {

--- a/src/main/java/javapns/notification/Payload.java
+++ b/src/main/java/javapns/notification/Payload.java
@@ -136,9 +136,9 @@ public abstract class Payload {
    * @return byte[] bytes ready to be streamed directly to Apple servers
    */
   public byte[] getPayloadAsBytes() throws Exception {
-    final byte[] payload = getPayloadAsBytesUnchecked();
-    validateMaximumPayloadSize(payload.length);
-    return payload;
+    final byte[] payloadBytesUnchecked = getPayloadAsBytesUnchecked();
+    validateMaximumPayloadSize(payloadBytesUnchecked.length);
+    return payloadBytesUnchecked;
   }
 
   /**

--- a/src/main/java/javapns/notification/PushNotificationManager.java
+++ b/src/main/java/javapns/notification/PushNotificationManager.java
@@ -43,7 +43,7 @@ public class PushNotificationManager {
   /* Special identifier that tells the manager to generate a sequential identifier for each payload pushed */
   private static final int SEQUENTIAL_IDENTIFIER = -1;
 
-  private static int TESTS_SERIAL_NUMBER = 1;
+  private static int testsSerialNumber = 1;
 
   private static boolean useEnhancedNotificationFormat = true;
   private static boolean heavyDebugMode = false;
@@ -627,7 +627,7 @@ public class PushNotificationManager {
       } else {
         final long ctime = System.currentTimeMillis();
         final long ttl = requestedExpiry * 1000; // time-to-live in milliseconds
-        final Long expiryDateInSeconds = ((ctime + ttl) / 1000L);
+        final Long expiryDateInSeconds = (ctime + ttl) / 1000L;
         bao.write(intTo4ByteArray(expiryDateInSeconds.intValue()));
         message.setExpiry(ctime + ttl);
       }
@@ -781,7 +781,7 @@ public class PushNotificationManager {
 
   private String buildDebugAlert(final Payload payload, final int identifier, final String deviceToken) {
     final StringBuilder alert = new StringBuilder();
-    alert.append("JAVAPNS DEBUG ALERT ").append(TESTS_SERIAL_NUMBER++).append("\n");
+    alert.append("JAVAPNS DEBUG ALERT ").append(testsSerialNumber++).append("\n");
 
     /* Current date & time */
     alert.append(new SimpleDateFormat("yyyy/MM/dd HH:mm:ss").format(System.currentTimeMillis())).append("\n");

--- a/src/main/java/javapns/notification/PushNotificationPayload.java
+++ b/src/main/java/javapns/notification/PushNotificationPayload.java
@@ -177,8 +177,7 @@ public class PushNotificationPayload extends Payload {
    * @return a blank payload that can be customized
    */
   public static PushNotificationPayload complex() {
-    final PushNotificationPayload payload = new PushNotificationPayload();
-    return payload;
+    return new PushNotificationPayload();
   }
 
   /**
@@ -189,8 +188,7 @@ public class PushNotificationPayload extends Payload {
    * @throws JSONException if any exception occurs parsing the JSON string
    */
   public static PushNotificationPayload fromJSON(final String rawJSON) throws JSONException {
-    final PushNotificationPayload payload = new PushNotificationPayload(rawJSON);
-    return payload;
+    return new PushNotificationPayload(rawJSON);
   }
 
   /**

--- a/src/main/java/javapns/notification/ResponsePacketReader.java
+++ b/src/main/java/javapns/notification/ResponsePacketReader.java
@@ -90,23 +90,23 @@ class ResponsePacketReader {
       return null;
     }
 
-    final int identifier_byte1 = input.read();
-    if (identifier_byte1 < 0) {
+    final int identifierByte1 = input.read();
+    if (identifierByte1 < 0) {
       return null;
     }
-    final int identifier_byte2 = input.read();
-    if (identifier_byte2 < 0) {
+    final int identifierByte2 = input.read();
+    if (identifierByte2 < 0) {
       return null;
     }
-    final int identifier_byte3 = input.read();
-    if (identifier_byte3 < 0) {
+    final int identifierByte3 = input.read();
+    if (identifierByte3 < 0) {
       return null;
     }
-    final int identifier_byte4 = input.read();
-    if (identifier_byte4 < 0) {
+    final int identifierByte4 = input.read();
+    if (identifierByte4 < 0) {
       return null;
     }
-    final int identifier = (identifier_byte1 << 24) + (identifier_byte2 << 16) + (identifier_byte3 << 8) + (identifier_byte4);
+    final int identifier = (identifierByte1 << 24) + (identifierByte2 << 16) + (identifierByte3 << 8) + (identifierByte4);
     return new ResponsePacket(command, status, identifier);
   }
 }

--- a/src/main/java/javapns/notification/management/VPNPayload.java
+++ b/src/main/java/javapns/notification/management/VPNPayload.java
@@ -11,7 +11,7 @@ import org.json.JSONObject;
 class VPNPayload extends MobileConfigPayload {
   public static final String VPNTYPE_L2TP = "L2TP";
   public static final String VPNTYPE_PPTP = "PPTP";
-  public static final String VPNTYPE_IPSec = "IPSec";
+  public static final String VPNTYPE_IP_SEC = "IPSec";
 
   public VPNPayload(final int payloadVersion, final String payloadOrganization, final String payloadIdentifier, final String payloadDisplayName, final String userDefinedName, final boolean overridePrimary, final String vpnType) throws JSONException {
     super(payloadVersion, "com.apple.vpn.managed", payloadOrganization, payloadIdentifier, payloadDisplayName);

--- a/src/main/java/javapns/notification/management/WiFiPayload.java
+++ b/src/main/java/javapns/notification/management/WiFiPayload.java
@@ -9,10 +9,10 @@ import org.json.JSONObject;
  * @author Sylvain Pedneault
  */
 class WiFiPayload extends MobileConfigPayload {
-  public WiFiPayload(final int payloadVersion, final String payloadOrganization, final String payloadIdentifier, final String payloadDisplayName, final String SSID_STR, final boolean hiddenNetwork, final String encryptionType) throws JSONException {
+  public WiFiPayload(final int payloadVersion, final String payloadOrganization, final String payloadIdentifier, final String payloadDisplayName, final String ssidStr, final boolean hiddenNetwork, final String encryptionType) throws JSONException {
     super(payloadVersion, "com.apple.wifi.managed", payloadOrganization, payloadIdentifier, payloadDisplayName);
     final JSONObject payload = getPayload();
-    payload.put("SSID_STR", SSID_STR);
+    payload.put("SSID_STR", ssidStr);
     payload.put("HIDDEN_NETWORK", hiddenNetwork);
     payload.put("EncryptionType", encryptionType);
   }

--- a/src/main/java/javapns/notification/transmission/NotificationThread.java
+++ b/src/main/java/javapns/notification/transmission/NotificationThread.java
@@ -195,17 +195,17 @@ public class NotificationThread implements Runnable, PushQueue {
       notificationManager.initializeConnection(server);
       for (int i = 0; i < total; i++) {
         final Device device;
-        final Payload payload;
+        final Payload payloadLocal;
         if (devices != null) {
           device = devices.get(i);
-          payload = this.payload;
+          payloadLocal = this.payload;
         } else {
           final PayloadPerDevice message = messages.get(i);
           device = message.getDevice();
-          payload = message.getPayload();
+          payloadLocal = message.getPayload();
         }
         final int message = newMessageIdentifier();
-        final PushedNotification notification = notificationManager.sendNotification(device, payload, false, message);
+        final PushedNotification notification = notificationManager.sendNotification(device, payloadLocal, false, message);
         notifications.add(notification);
         try {
           if (sleepBetweenNotifications > 0) {

--- a/src/main/java/javapns/notification/transmission/NotificationThreads.java
+++ b/src/main/java/javapns/notification/transmission/NotificationThreads.java
@@ -353,12 +353,8 @@ public class NotificationThreads extends ThreadGroup implements PushQueue {
    * @throws InterruptedException
    */
   public void waitForAllThreads() throws InterruptedException {
-    try {
-      synchronized (finishPoint) {
-        finishPoint.wait();
-      }
-    } catch (final IllegalMonitorStateException e) {
-      /* All threads are most likely already done, so we ignore this */
+    synchronized (finishPoint) {
+      finishPoint.wait();
     }
   }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2235 - IllegalMonitorStateException should not be caught.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
squid:HiddenFieldCheck - Local variables should not shadow class fields.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S3008 - Static non-final field names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2235
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:HiddenFieldCheck
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S3008
Please let me know if you have any questions.
George Kankava
