### PR TITLE
Fixed PushedNotification.toString when token is invalid

### DIFF
--- a/src/main/java/javapns/notification/PushedNotification.java
+++ b/src/main/java/javapns/notification/PushedNotification.java
@@ -241,7 +241,14 @@ public class PushedNotification {
     final StringBuilder msg = new StringBuilder();
     msg.append("[").append(identifier).append("]");
     msg.append(transmissionCompleted ? " transmitted " + payload + " on " + getLatestTransmissionAttempt() : " not transmitted");
-    msg.append(" to token ").append(device.getToken().substring(0, 5)).append("..").append(device.getToken().substring(59, 64));
+    msg.append(" to token " );
+    try {
+      // Test if token is valid
+      new BasicDevice(device.getToken(), true);
+      msg.append(device.getToken().substring(0, 5) + ".." + device.getToken().substring(59, 64));
+    } catch (Exception e) {
+      msg.append("INVALID_TOKEN:[" + device.getToken() + "]");
+    }
     if (response != null) {
       msg.append("  ").append(response.getMessage());
     }


### PR DESCRIPTION
Fixed PushedNotification.toString when token is invalid

Code cherry picked by hand from
https://code.google.com/archive/p/javapns/source/default/commits

There is more there to consider.
